### PR TITLE
Add tag registry

### DIFF
--- a/src/main/java/seedu/address/model/tag/Tag.java
+++ b/src/main/java/seedu/address/model/tag/Tag.java
@@ -1,17 +1,25 @@
 package seedu.address.model.tag;
 
-import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+
+import java.util.Objects;
+
+import seedu.address.commons.util.ToStringBuilder;
 
 /**
  * Represents a Tag in the address book.
- * Guarantees: immutable; name is valid as declared in {@link #isValidTagName(String)}
+ * Guarantees: immutable; tag is valid as declared in {@link #isValidTagName(String)}; all details are present and not
+ * null.
  */
 public class Tag {
 
-    public static final String MESSAGE_CONSTRAINTS = "Tags names should be alphanumeric";
-    public static final String VALIDATION_REGEX = "\\p{Alnum}+";
+    public static final String MESSAGE_CONSTRAINTS = "Tags must be between 2 and 50 characters long and can only "
+            + "contain letters, numbers, apostrophes, spaces, periods, hyphens, underscores, plus signs,"
+            + " and ampersands. The tag cannot be blank and must not already exist.";
+    public static final String VALIDATION_REGEX = "^[a-zA-Z0-9' ._+&-]{2,50}$";
 
+    // Identity fields
     public final String tagName;
 
     /**
@@ -20,9 +28,10 @@ public class Tag {
      * @param tagName A valid tag name.
      */
     public Tag(String tagName) {
-        requireNonNull(tagName);
+        requireAllNonNull(tagName);
         checkArgument(isValidTagName(tagName), MESSAGE_CONSTRAINTS);
-        this.tagName = tagName;
+
+        this.tagName = tagName.toUpperCase();
     }
 
     /**
@@ -32,6 +41,33 @@ public class Tag {
         return test.matches(VALIDATION_REGEX);
     }
 
+    public String getTagName() {
+        return tagName;
+    }
+
+    /**
+     * Checks if two tags have the same unique identifiers.
+     * This defines a weaker notion of equality between two tags.
+     *
+     * @param otherTag tag to be compared with.
+     * @return true if both tags have the same tag name. false otherwise.
+     */
+    public boolean isSameTag(Tag otherTag) {
+        if (otherTag == this) {
+            return true;
+        }
+
+        return otherTag != null
+                && tagName.equals(otherTag.tagName);
+    }
+
+    /**
+     * Checks if two tag have the same identity and data fields and associations.
+     * This defines a stronger notion of equality between two tags.
+     *
+     * @param other Object to be compared with.
+     * @return true if both tags have the same identity and data fields and associations. false otherwise.
+     */
     @Override
     public boolean equals(Object other) {
         if (other == this) {
@@ -49,14 +85,17 @@ public class Tag {
 
     @Override
     public int hashCode() {
-        return tagName.hashCode();
+        // use this method for custom fields hashing instead of implementing your own
+        return Objects.hash(tagName);
     }
 
     /**
      * Format state as text for viewing.
      */
     public String toString() {
-        return '[' + tagName + ']';
+        return new ToStringBuilder(this)
+                .add("tag name", tagName)
+                .toString();
     }
 
 }

--- a/src/main/java/seedu/address/model/tag/TagRegistry.java
+++ b/src/main/java/seedu/address/model/tag/TagRegistry.java
@@ -1,0 +1,194 @@
+package seedu.address.model.tag;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableMap;
+import seedu.address.model.tag.exceptions.DuplicateTagException;
+import seedu.address.model.tag.exceptions.TagNotFoundException;
+
+/**
+ * Represents a hashmap of tags that enforces uniqueness between its elements and does not allow nulls.
+ * The key of the hashmap is the tag name in uppercase to ensure case insensitivity. The tag name acts as a unique
+ * identifier for the tags, as such only one tag should exist for a particular tag name. Since a hashmap is used,
+ * adding, updating  of tags are ensured to remain unique. Deleting of tags also ensures that the
+ * intended tag is deleted.
+ *
+ * Supports a minimal set of hashmap operations.
+ *
+ * TagRegistry is a singleton.
+ */
+public class TagRegistry implements Iterable<Tag> {
+
+    // Singleton instance
+    private static final TagRegistry SINGLETON = new TagRegistry();
+
+    private final ObservableMap<String, Tag> internalHashmap = FXCollections.observableHashMap();
+    private final ObservableMap<String, Tag> internalUnmodifiableMap =
+            FXCollections.unmodifiableObservableMap(internalHashmap);
+
+    // Private constructor to prevent instantiation
+    private TagRegistry() {}
+
+    /**
+     * Returns the singleton instance of the TagRegistry.
+     * Factory method of the TagRegistry class.
+     *
+     * @return singleton instance of the TagRegistry.
+     */
+    public static TagRegistry of() {
+        return SINGLETON;
+    }
+
+    /**
+     * Checks if the hashmap contains an equivalent tag with the same tag name as the given argument.
+     *
+     * @param toCheck the tag to check if it exists in the hashmap as a key.
+     * @return true if the list contains an equivalent tag with the same tag name as the given argument.
+     *         false otherwise.
+     */
+    public boolean contains(Tag toCheck) {
+        requireNonNull(toCheck);
+        return internalHashmap.containsKey(toCheck.getTagName());
+    }
+
+    /**
+     * Gets the existing tag with the specified tag name.
+     * {@code tagName} must exist in the hashmap.
+     *
+     * @param tagName the name of the tag to get.
+     * @return tag with specified tag name.
+     * @throws TagNotFoundException if tag is not found.
+     */
+    public Tag get(String tagName) {
+        requireNonNull(tagName);
+
+        String upperTagName = tagName.toUpperCase();
+        if (!internalHashmap.containsKey(upperTagName)) {
+            throw new TagNotFoundException();
+        }
+
+        return internalHashmap.get(upperTagName);
+    }
+
+    /**
+     * Adds a tag with the given tag name to the hashmap.
+     * {@code tag} must not exist in the hashmap.
+     *
+     * @param toAdd the tag to add.
+     * @throws DuplicateTagException if the tag name to add already exists in the hashmap.
+     */
+    public void add(Tag toAdd) {
+        requireNonNull(toAdd);
+        if (contains(toAdd)) {
+            throw new DuplicateTagException();
+        }
+        internalHashmap.put(toAdd.getTagName(), toAdd);
+    }
+
+    /**
+     * Replaces the tag {@code target} in the hashmap with {@code editedTag}.
+     * {@code target} must exist in the hashmap.
+     * The new key of {@code editedTag} must not be the same as another existing tag in the hashmap.
+     *
+     * @param target the tag to be replaced.
+     * @param editedTag the tag to replace the target tag with.
+     * @throws DuplicateTagException if the replacement is equivalent to another existing tag in the hashmap.
+     */
+    public void setTag(Tag target, Tag editedTag) {
+        requireAllNonNull(target, editedTag);
+
+        if (!contains(target)) {
+            throw new TagNotFoundException();
+        }
+
+        if (!target.isSameTag(editedTag) && contains(editedTag)) {
+            throw new DuplicateTagException();
+        }
+
+        remove(target);
+        add(editedTag);
+    }
+
+
+    /**
+     * Removes the tag with the specified tag name from the hashmap.
+     * {@code tagName} must exist in the hashmap.
+     *
+     * @param toRemove the tag to remove.
+     * @throws TagNotFoundException if tag is not found.
+     */
+    public void remove(Tag toRemove) {
+        requireNonNull(toRemove);
+
+        if (!contains(toRemove)) {
+            throw new TagNotFoundException();
+        }
+
+        internalHashmap.remove(toRemove.getTagName());
+    }
+
+    /**
+     * Replaces the contents of this hashmap with {@code tags}.
+     * {@code tags} must not contain duplicate tags.
+     *
+     * @param tags the replacement list.
+     */
+    public void setTags(List<Tag> tags) {
+        requireAllNonNull(tags);
+
+        if (!tagsAreUnique(tags)) {
+            throw new DuplicateTagException();
+        }
+
+        internalHashmap.clear();
+        for (Tag tag : tags) {
+            internalHashmap.put(tag.getTagName(), tag);
+        }
+    }
+
+    /**
+     * Returns the backing list as an unmodifiable {@code ObservableMap}.
+     *
+     * @return the unmodifiable map.
+     */
+    public ObservableMap<String, Tag> asUnmodifiableObservableMap() {
+        return internalUnmodifiableMap;
+    }
+
+    @Override
+    public Iterator<Tag> iterator() {
+        return internalHashmap.values().iterator();
+    }
+
+    @Override
+    public int hashCode() {
+        return internalHashmap.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return internalHashmap.toString();
+    }
+
+    /**
+     * Checks if {@code tags} contains only unique tags.
+     *
+     * @return true if {@code tags} contains only unique tags. false otherwise.
+     */
+    private boolean tagsAreUnique(List<Tag> tags) {
+        Set<String> seenNames = new HashSet<>();
+        for (Tag tag : tags) {
+            if (!seenNames.add(tag.getTagName())) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/src/main/java/seedu/address/model/tag/TagRegistry.java
+++ b/src/main/java/seedu/address/model/tag/TagRegistry.java
@@ -50,7 +50,7 @@ public class TagRegistry implements Iterable<Tag> {
      * Checks if the hashmap contains an equivalent tag with the same tag name as the given argument.
      *
      * @param toCheck the tag to check if it exists in the hashmap as a key.
-     * @return true if the list contains an equivalent tag with the same tag name as the given argument.
+     * @return true if the hashmap contains an equivalent tag with the same tag name as the given argument.
      *         false otherwise.
      */
     public boolean contains(Tag toCheck) {
@@ -154,7 +154,7 @@ public class TagRegistry implements Iterable<Tag> {
     }
 
     /**
-     * Returns the backing list as an unmodifiable {@code ObservableMap}.
+     * Returns the backing map as an unmodifiable {@code ObservableMap}.
      *
      * @return the unmodifiable map.
      */

--- a/src/main/java/seedu/address/model/tag/exceptions/DuplicateTagException.java
+++ b/src/main/java/seedu/address/model/tag/exceptions/DuplicateTagException.java
@@ -1,0 +1,11 @@
+package seedu.address.model.tag.exceptions;
+
+/**
+ * Signals that the operation will result in duplicate Tag (Tag are considered duplicates if they have the same
+ * case-insensitive string).
+ */
+public class DuplicateTagException extends RuntimeException {
+    public DuplicateTagException() {
+        super("Operation would result in duplicate tags");
+    }
+}

--- a/src/main/java/seedu/address/model/tag/exceptions/TagNotFoundException.java
+++ b/src/main/java/seedu/address/model/tag/exceptions/TagNotFoundException.java
@@ -1,0 +1,6 @@
+package seedu.address.model.tag.exceptions;
+
+/**
+ * Signals that the operation is unable to find the specified tag.
+ */
+public class TagNotFoundException extends RuntimeException {}


### PR DESCRIPTION
Fixes #69 

Note that the tag registry is a singleton and also uses hashmap rather than list like unique person list since tags are referenced by their tag name rather than an index. 