### PR TITLE
Fix delete property preference not updating tag counter properly

### DIFF
--- a/src/main/java/seedu/address/logic/commands/DeletePreferenceCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeletePreferenceCommand.java
@@ -112,7 +112,8 @@ public class DeletePreferenceCommand extends Command {
 
         Set<Tag> tags = new HashSet<>(preferenceToDelete.getTags());
 
-        for (Tag tag: tags) {
+        for (Tag tagReference: tags) {
+            Tag tag = tagRegistry.get(tagReference.getTagName());
             List<PropertyPreference> tagPropertyPreferences = new ArrayList<>(tag.getPropertyPreferences());
             tagPropertyPreferences.remove(preferenceToDelete);
 


### PR DESCRIPTION
Fixes #154 

Side Note:
This PR unveils issues with bidirectional navigability, immutability and editing of persons, as editing a person's identity fields will require updating its associations to ensure that a new person is referenced.