### PR TITLE
Fix matchPerson and matchProperty predicates

### DIFF
--- a/src/main/java/seedu/address/model/listing/predicates/ListingMatchesPreferencePredicate.java
+++ b/src/main/java/seedu/address/model/listing/predicates/ListingMatchesPreferencePredicate.java
@@ -1,5 +1,6 @@
 package seedu.address.model.listing.predicates;
 
+import java.util.Collections;
 import java.util.Set;
 import java.util.function.Predicate;
 
@@ -10,6 +11,7 @@ import seedu.address.model.tag.Tag;
 
 /**
  * Tests if a {@code Listing} matches a {@code PropertyPreference}.
+ * Used for {@code MatchPersonCommand}.
  */
 public class ListingMatchesPreferencePredicate implements Predicate<Listing> {
     private final PropertyPreference preferenceToMatch;
@@ -22,20 +24,20 @@ public class ListingMatchesPreferencePredicate implements Predicate<Listing> {
     public boolean test(Listing listing) {
         Set<Tag> tagsToMatch = preferenceToMatch.getTags();
 
-        if (!listing.getAvailability()) {
+        // If unavailable or listing is owned by a person, reject.
+        if (!listing.getAvailability() || listing.getOwners().contains(preferenceToMatch.getPerson())) {
             return false;
         }
 
-        if (listing.getOwners().contains(preferenceToMatch.getPerson())) {
-            return false;
-        }
-
-        if (tagsToMatch.isEmpty() || listing.getPriceRange().doPriceRangeOverlap(preferenceToMatch.getPriceRange())) {
+        // If price range overlaps, accept.
+        boolean priceRangeOverlaps = listing.getPriceRange().doPriceRangeOverlap(preferenceToMatch.getPriceRange());
+        if (priceRangeOverlaps) {
             return true;
         }
 
+        // If any tags match and price range doesn't overlap, accept. Rejects otherwise.
         Set<Tag> listingTags = listing.getTags();
-        return listingTags.containsAll(tagsToMatch);
+        return !Collections.disjoint(listingTags, tagsToMatch);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/predicates/PersonMatchesPropertyPredicate.java
+++ b/src/main/java/seedu/address/model/person/predicates/PersonMatchesPropertyPredicate.java
@@ -35,11 +35,6 @@ public class PersonMatchesPropertyPredicate implements Predicate<Person> {
             return false;
         }
 
-        // If listing is not available, reject.
-        if (!listingToMatch.getAvailability()) {
-            return false;
-        }
-
         Set<Tag> tagsToMatch = listingToMatch.getTags();
         for (PropertyPreference pref : propertyPreferences) {
             // If any tag matches, return true.

--- a/src/main/java/seedu/address/model/person/predicates/PersonMatchesPropertyPredicate.java
+++ b/src/main/java/seedu/address/model/person/predicates/PersonMatchesPropertyPredicate.java
@@ -12,6 +12,7 @@ import seedu.address.model.tag.Tag;
 
 /**
  * Tests that a {@code Person}'s property preferences matches a {@code Listing}.
+ * Used for {@code MatchListingCommand}.
  */
 public class PersonMatchesPropertyPredicate implements Predicate<Person> {
     private final Listing listingToMatch;
@@ -23,34 +24,36 @@ public class PersonMatchesPropertyPredicate implements Predicate<Person> {
     @Override
     public boolean test(Person person) {
         List<PropertyPreference> propertyPreferences = person.getPropertyPreferences();
+
+        // If person has no preferences, reject everything.
         if (propertyPreferences.isEmpty()) {
             return false;
         }
 
+        // If person owns the listing, reject.
         if (listingToMatch.getOwners().contains(person)) {
             return false;
         }
 
+        // If listing is not available, reject.
         if (!listingToMatch.getAvailability()) {
             return false;
         }
 
         Set<Tag> tagsToMatch = listingToMatch.getTags();
-        if (tagsToMatch.isEmpty()) {
-            return true;
-        }
-
         for (PropertyPreference pref : propertyPreferences) {
-            //Checks if any tag matches
+            // If any tag matches, return true.
             if (!Collections.disjoint(pref.getTags(), tagsToMatch)) {
                 return true;
             }
 
-            //Checks if price range matches
+            // If price range matches, return true.
             if (pref.getPriceRange().doPriceRangeOverlap(listingToMatch.getPriceRange())) {
                 return true;
             }
         }
+
+        // If no preferences match, return false.
         return false;
     }
 


### PR DESCRIPTION
Fixes #243

Initial
![image](https://github.com/user-attachments/assets/dab2791d-6633-47e0-a34e-5703d0b2c4f6)

`matchPerson 3 1`
![image](https://github.com/user-attachments/assets/7bbe6c41-9a21-40d7-8c52-a00e4ac9a9f3)

back to initial then `matchProperty 4`
![image](https://github.com/user-attachments/assets/6a653ab4-e26a-46ee-b50c-cf53f1a31e15)
