### PR TITLE
Update parser response messages

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -22,7 +22,7 @@ public class Messages {
     public static final String MESSAGE_DELETE_TAG_PREAMBLE_FOUND = "Delete tag should not have preamble. \n%1$s";
     public static final String MESSAGE_SEARCH_PERSON_TAG_PREAMBLE_FOUND = "Search person should not have preamble. "
             + "\n%1$s";
-    public static final String MESSAGE_SEARCH_PROPERTY_TAG_PREAMBLE_FOUND = "Search property should not have preamble. "
+    public static final String MESSAGE_SEARCH_LISTING_TAG_PREAMBLE_FOUND = "Search listing should not have preamble. "
             + "\n%1$s";
     public static final String MESSAGE_HOUSE_OR_UNIT_NUMBER_REQUIRED =
             "Either house number or unit number must be provided, but not both.\n%1$s";
@@ -31,34 +31,22 @@ public class Messages {
     public static final String MESSAGE_PHONE_REQUIRED = "Phone must be provided.\n%1$s";
     public static final String MESSAGE_EMAIL_REQUIRED = "Email must be provided.\n%1$s";
     public static final String MESSAGE_TAG_OR_NEW_TAG_REQUIRED = "Provide at least a new tag or existing tag. \n%1$s";
-    public static final String MESSAGE_PREFERENCE_TAG_REQUIRED_FOR_DELETE = "At least one preference Tag must be "
-            + "provided for deletion.\n%1$s";
-    public static final String MESSAGE_PROPERTY_TAG_REQUIRED_FOR_DELETE = "At least one property Tag must be "
+    public static final String MESSAGE_NEW_TAG_REQUIRED = "Provide at least a new tag. \n%1$s";
+    public static final String MESSAGE_LISTING_TAG_REQUIRED_FOR_DELETE = "At least one listing Tag must be "
             + "provided for deletion.\n%1$s";
     public static final String MESSAGE_TAG_REQUIRED_FOR_DELETE = "At least one Tag must be "
             + "provided for deletion.\n%1$s";
     public static final String MESSAGE_POSTAL_CODE_REQUIRED = "Postal code must be provided. \n%1$s";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid. \n%1$s";
-    public static final String MESSAGE_INVALID_PERSON_OR_PREFERENCE_DISPLAYED_INDEX = "The person or preference index "
-            + "provided is invalid. \n%1$s";
-    public static final String MESSAGE_INVALID_PERSON_OR_LISTING_DISPLAYED_INDEX = "The person or listing index "
-            + "provided is invalid. \n%1$s";
-    public static final String MESSAGE_INVALID_OWNER_OR_LISTING_DISPLAYED_INDEX = "The owner or listing index "
-            + "provided is invalid. \n%1$s";
     public static final String MESSAGE_INVALID_LISTING_DISPLAYED_INDEX = "The listing index provided is invalid. "
             + "\n%1$s";
     public static final String MESSAGE_INVALID_OWNER_DISPLAYED_INDEX = "The owner index provided is invalid. \n%1$s";
-    public static final String MESSAGE_DELETE_PROPERTY_TAG_SUCCESS = "Tag(s) in property %s deleted: %s";
-    public static final String MESSAGE_TAG_NOT_FOUND_IN_PROPERTY = "Tag(s) not found in property: %s\n%s";
+    public static final String MESSAGE_DELETE_LISTING_TAG_SUCCESS = "Tag(s) in listing %s deleted: %s";
+    public static final String MESSAGE_TAG_NOT_FOUND_IN_LISTING = "Tag(s) not found in listing: %s\n%s";
     public static final String MESSAGE_TAG_NOT_FOUND_IN_PREFERENCE = "Tag(s) not found in property preference: %s\n%s";
     public static final String MESSAGE_INVALID_PREFERENCE_DISPLAYED_INDEX = "The property preference index provided "
             + "is invalid.\n%1$s";
     public static final String MESSAGE_ADD_TAG_PREAMBLE_FOUND = "Add tag should not have preamble. \n%1$s";
-    public static final String MESSAGE_TAG_OR_NEW_TAG_PREFIX_EMPTY_VALUE = "At least one given tag or new tag prefix "
-            + "is empty.\n%1$s";
-    public static final String MESSAGE_NEW_TAG_PREFIX_EMPTY_VALUE = "At least one new tag prefix "
-            + "is empty.\n%1$s";
-    public static final String MESSAGE_INDEX_REQUIRED = "Please provide 1 index for this command";
     public static final String MESSAGE_ARGUMENTS_EMPTY = "Arguments should not be empty. \n%1$s";
     public static final String MESSAGE_DUPLICATE_FIELDS =
             "Multiple values specified for the following single-valued field(s): ";
@@ -67,20 +55,15 @@ public class Messages {
     public static final String MESSAGE_MISSING_KEYWORD =
             "ERROR: Missing parameters. You must provide at least one keyword.\n%s";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%d persons found matching the keywords.";
-    public static final String MESSAGE_SEARCH_PERSON_TAG_NOT_FOUND = "Tag '%s' does not exist.";
     public static final String MESSAGE_SEARCH_PERSON_TAG_MISSING_PARAMS =
             "At least one tag [t/TAG] must be specified for search.\n%s";
     public static final String MESSAGE_SEARCH_PERSON_TAGS_SUCCESS = "%d persons matching the tags.";
     public static final String MESSAGE_SEARCH_PERSON_TAGS_NO_MATCH = "No persons matching the tags.";
-    public static final String MESSAGE_SEARCH_PERSON_TAG_PREFIX_EMPTY =
-            "Tag prefix specified but no tag value given. Please specify a tag after t/.\n%S";
-    public static final String MESSAGE_SEARCH_PROPERTY_TAGS_SUCCESS = "%d properties matching the tags!";
-    public static final String MESSAGE_SEARCH_PROPERTY_TAGS_NO_MATCH = "No properties matching the tags.";
+    public static final String MESSAGE_SEARCH_LISTING_TAGS_SUCCESS = "%d listings matching the tags!";
+    public static final String MESSAGE_SEARCH_LISTING_TAGS_NO_MATCH = "No listings matching the tags.";
     public static final String MESSAGE_TAG_DOES_NOT_EXIST = "Tag '%s' does not exist in the system.\n%s";
     public static final String MESSAGE_SEARCH_PROPERTY_TAG_MISSING_PARAMS =
             "At least one [t/TAG] needs to be specified for search.\n%s";
-    public static final String MESSAGE_SEARCH_PROPERTY_TAG_PREFIX_EMPTY =
-            "Tag prefix specified but no tag value given. Please specify a tag after t/.\n%s";
 
     public static final String MESSAGE_ONE_INDEX_EXPECTED = "This command expects only 1 index to be provided. \n%s";
 
@@ -100,21 +83,6 @@ public class Messages {
                 Stream.of(duplicatePrefixes).map(Prefix::toString).collect(Collectors.toSet());
 
         return MESSAGE_DUPLICATE_FIELDS + String.join(" ", duplicateFields);
-    }
-
-    /**
-     * Formats basic property address details (postal code + unit/house number) for display.
-     */
-    public static String formatPropertyDetails(Listing property) {
-        StringBuilder details = new StringBuilder();
-        details.append(" ").append(property.getPostalCode().toString());
-
-        if (property.getUnitNumber() != null) {
-            details.append(" ").append(property.getUnitNumber().toString());
-        } else if (property.getHouseNumber() != null) {
-            details.append(" ").append(property.getHouseNumber().toString());
-        }
-        return details.toString();
     }
 
     /**

--- a/src/main/java/seedu/address/logic/commands/AddPreferenceCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddPreferenceCommand.java
@@ -44,8 +44,8 @@ public class AddPreferenceCommand extends Command {
             + PREFIX_NEW_TAG + "spacious";
 
     public static final String MESSAGE_SUCCESS = "New property preference added to %1$s";
-    public static final String MESSAGE_DUPLICATE_TAGS = "At least one of the new tags given already exist.%1$s\n";
-    public static final String MESSAGE_INVALID_TAGS = "At least one of the tags given does not exist.%1$s\n";
+    public static final String MESSAGE_DUPLICATE_TAGS = "At least one of the new tags given already exist.\n%1$s";
+    public static final String MESSAGE_INVALID_TAGS = "At least one of the tags given does not exist.\n%1$s";
 
     private final Index targetPersonIndex;
     private final PriceRange priceRange;

--- a/src/main/java/seedu/address/logic/commands/DeleteListingTagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteListingTagCommand.java
@@ -65,7 +65,7 @@ public class DeleteListingTagCommand extends Command {
             }
             Tag tagToRemove = model.getTag(tagName);
             if (!listingToEdit.getTags().contains(tag)) {
-                throw new CommandException(String.format(Messages.MESSAGE_TAG_NOT_FOUND_IN_PROPERTY, tagName,
+                throw new CommandException(String.format(Messages.MESSAGE_TAG_NOT_FOUND_IN_LISTING, tagName,
                         MESSAGE_USAGE));
             }
             deletedTags.add(tagToRemove);
@@ -81,7 +81,7 @@ public class DeleteListingTagCommand extends Command {
 
         model.resetAllLists();
 
-        return new CommandResult(String.format(Messages.MESSAGE_DELETE_PROPERTY_TAG_SUCCESS,
+        return new CommandResult(String.format(Messages.MESSAGE_DELETE_LISTING_TAG_SUCCESS,
                 listingToEdit.getPostalCode(), Messages.format(deletedTags)));
     }
 

--- a/src/main/java/seedu/address/logic/commands/SearchListingByTagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SearchListingByTagCommand.java
@@ -78,9 +78,9 @@ public class SearchListingByTagCommand extends Command {
         List<Listing> filteredListings = model.getSortedFilteredListingList();
 
         if (filteredListings.isEmpty()) {
-            return new CommandResult(Messages.MESSAGE_SEARCH_PROPERTY_TAGS_NO_MATCH);
+            return new CommandResult(Messages.MESSAGE_SEARCH_LISTING_TAGS_NO_MATCH);
         } else {
-            return new CommandResult(String.format(Messages.MESSAGE_SEARCH_PROPERTY_TAGS_SUCCESS,
+            return new CommandResult(String.format(Messages.MESSAGE_SEARCH_LISTING_TAGS_SUCCESS,
                     filteredListings.size()));
         }
     }

--- a/src/main/java/seedu/address/logic/parser/AddListingCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddListingCommandParser.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_ADD_LISTING_PREAMBLE_FOUND;
+import static seedu.address.logic.Messages.MESSAGE_ARGUMENTS_EMPTY;
 import static seedu.address.logic.Messages.MESSAGE_HOUSE_OR_UNIT_NUMBER_REQUIRED;
 import static seedu.address.logic.Messages.MESSAGE_LOWER_GREATER_THAN_UPPER_FOR_PRICE;
 import static seedu.address.logic.Messages.MESSAGE_POSTAL_CODE_REQUIRED;
@@ -46,7 +47,7 @@ public class AddListingCommandParser implements Parser<AddListingCommand> {
                         PREFIX_LOWER_BOUND_PRICE, PREFIX_UPPER_BOUND_PRICE, PREFIX_PROPERTY_NAME, PREFIX_TAG,
                         PREFIX_NEW_TAG);
 
-        checkCommandFormat(argMultimap);
+        checkCommandFormat(argMultimap, args);
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_POSTAL_CODE, PREFIX_UNIT_NUMBER, PREFIX_HOUSE_NUMBER,
                 PREFIX_LOWER_BOUND_PRICE, PREFIX_UPPER_BOUND_PRICE, PREFIX_PROPERTY_NAME);
         PostalCode postalCode = ParserUtil.parsePostalCode(argMultimap.getValue(PREFIX_POSTAL_CODE).get());
@@ -91,11 +92,16 @@ public class AddListingCommandParser implements Parser<AddListingCommand> {
         }
     }
 
-    private static void checkCommandFormat(ArgumentMultimap argMultimap) throws ParseException {
+    private static void checkCommandFormat(ArgumentMultimap argMultimap, String args) throws ParseException {
         boolean hasUnitNumber = argMultimap.getValue(PREFIX_UNIT_NUMBER).isPresent();
         boolean hasHouseNumber = argMultimap.getValue(PREFIX_HOUSE_NUMBER).isPresent();
         boolean hasExclusiveHouseOrUnitNumber = hasUnitNumber ^ hasHouseNumber;
         boolean hasPostalCode = argMultimap.getValue(PREFIX_POSTAL_CODE).isPresent();
+
+        if (args.trim().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_ARGUMENTS_EMPTY,
+                    AddListingCommand.MESSAGE_USAGE));
+        }
 
         if (!hasExclusiveHouseOrUnitNumber) {
             throw new ParseException(String.format(MESSAGE_HOUSE_OR_UNIT_NUMBER_REQUIRED,

--- a/src/main/java/seedu/address/logic/parser/AddListingTagCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddListingTagCommandParser.java
@@ -16,7 +16,8 @@ import seedu.address.logic.parser.exceptions.ParseException;
  * Parses input arguments and creates a new {@code AddListingTagCommand} object.
  */
 public class AddListingTagCommandParser implements Parser<AddListingTagCommand> {
-
+    private static final String WHITESPACE_REGEX = "\\s+";
+    private static final int EXPECTED_PREAMBLE_PARTS = 1;
     /**
      * Parses the given {@code String} of arguments in the context of the AddListingTagCommand
      * and returns an AddListingTagCommand object for execution.
@@ -56,7 +57,7 @@ public class AddListingTagCommandParser implements Parser<AddListingTagCommand> 
                     AddListingTagCommand.MESSAGE_USAGE));
         }
 
-        if (preamble.isEmpty() || preamble.split("\\s+").length != 1) {
+        if (preamble.isEmpty() || preamble.split(WHITESPACE_REGEX).length != EXPECTED_PREAMBLE_PARTS) {
             throw new ParseException(String.format(MESSAGE_ONE_INDEX_EXPECTED,
                     AddListingTagCommand.MESSAGE_USAGE));
         }

--- a/src/main/java/seedu/address/logic/parser/AddOwnerCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddOwnerCommandParser.java
@@ -13,6 +13,8 @@ import seedu.address.logic.parser.exceptions.ParseException;
  * Parses input arguments and creates a new {@code AddOwnerCommand} object.
  */
 public class AddOwnerCommandParser implements Parser<AddOwnerCommand> {
+    private static final String WHITESPACE_REGEX = "\\s+";
+    private static final int EXPECTED_PREAMBLE_PARTS = 2;
 
     /**
      * Parses the given {@code String} of arguments in the context of the AddOwnerCommand
@@ -43,7 +45,7 @@ public class AddOwnerCommandParser implements Parser<AddOwnerCommand> {
                     AddOwnerCommand.MESSAGE_USAGE));
         }
 
-        if (preamble.isEmpty() || preamble.split("\\s+").length != 2) {
+        if (preamble.isEmpty() || preamble.split(WHITESPACE_REGEX).length != EXPECTED_PREAMBLE_PARTS) {
             throw new ParseException(String.format(MESSAGE_EXPECTED_TWO_INDICES,
                     AddOwnerCommand.MESSAGE_USAGE));
         }

--- a/src/main/java/seedu/address/logic/parser/AddPersonCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddPersonCommandParser.java
@@ -10,7 +10,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 
 import java.util.ArrayList;
-import java.util.stream.Stream;
 
 import seedu.address.logic.commands.AddPersonCommand;
 import seedu.address.logic.parser.exceptions.ParseException;

--- a/src/main/java/seedu/address/logic/parser/AddPersonCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddPersonCommandParser.java
@@ -46,14 +46,6 @@ public class AddPersonCommandParser implements Parser<AddPersonCommand> {
         return new AddPersonCommand(person);
     }
 
-    /**
-     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
-     * {@code ArgumentMultimap}.
-     */
-    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
-        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
-    }
-
     private static void checkCommandFormat(ArgumentMultimap argMultimap, String args) throws ParseException {
         boolean hasName = argMultimap.getValue(PREFIX_NAME).isPresent();
         boolean hasPhone = argMultimap.getValue(PREFIX_PHONE).isPresent();

--- a/src/main/java/seedu/address/logic/parser/AddPreferenceCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddPreferenceCommandParser.java
@@ -20,6 +20,9 @@ import seedu.address.model.price.PriceRange;
  * Parses input arguments and creates a new {@code AddPreferenceCommand} object.
  */
 public class AddPreferenceCommandParser implements Parser<AddPreferenceCommand> {
+    private static final String WHITESPACE_REGEX = "\\s+";
+    private static final int EXPECTED_PREAMBLE_PARTS = 1;
+
     /**
      * Parses the given {@code String} of arguments in the context of the AddPreferenceCommand
      * and returns an AddPreferenceCommand object for execution.
@@ -70,7 +73,7 @@ public class AddPreferenceCommandParser implements Parser<AddPreferenceCommand> 
                     AddPreferenceCommand.MESSAGE_USAGE));
         }
 
-        if (preamble.isEmpty() || preamble.split("\\s+").length != 1) {
+        if (preamble.isEmpty() || preamble.split(WHITESPACE_REGEX).length != EXPECTED_PREAMBLE_PARTS) {
             throw new ParseException(String.format(MESSAGE_ONE_INDEX_EXPECTED,
                     AddPreferenceCommand.MESSAGE_USAGE));
         }

--- a/src/main/java/seedu/address/logic/parser/AddPreferenceTagCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddPreferenceTagCommandParser.java
@@ -17,7 +17,8 @@ import seedu.address.logic.parser.exceptions.ParseException;
  * Parses input arguments and creates a new {@code AddPreferenceTagCommand} object.
  */
 public class AddPreferenceTagCommandParser implements Parser<AddPreferenceTagCommand> {
-
+    private static final String WHITESPACE_REGEX = "\\s+";
+    private static final int EXPECTED_PREAMBLE_PARTS = 2;
     /**
      * Parses the given {@code String} of arguments in the context of the AddPreferenceTagCommand
      * and returns an AddPreferenceTagCommand object for execution.
@@ -59,7 +60,7 @@ public class AddPreferenceTagCommandParser implements Parser<AddPreferenceTagCom
                     AddPreferenceTagCommand.MESSAGE_USAGE));
         }
 
-        if (preamble.isEmpty() || preamble.split("\\s+").length != 2) {
+        if (preamble.isEmpty() || preamble.split(WHITESPACE_REGEX).length != EXPECTED_PREAMBLE_PARTS) {
             throw new ParseException(String.format(MESSAGE_EXPECTED_TWO_INDICES,
                     AddPreferenceTagCommand.MESSAGE_USAGE));
         }

--- a/src/main/java/seedu/address/logic/parser/AddTagCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddTagCommandParser.java
@@ -1,7 +1,8 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_ADD_TAG_PREAMBLE_FOUND;
-import static seedu.address.logic.Messages.MESSAGE_NEW_TAG_PREFIX_EMPTY_VALUE;
+import static seedu.address.logic.Messages.MESSAGE_ARGUMENTS_EMPTY;
+import static seedu.address.logic.Messages.MESSAGE_NEW_TAG_REQUIRED;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NEW_TAG;
 
 import java.util.Set;
@@ -24,19 +25,24 @@ public class AddTagCommandParser implements Parser<AddTagCommand> {
     public AddTagCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NEW_TAG);
         argMultimap.verifyNoDuplicateTagValues(AddTagCommand.MESSAGE_USAGE);
-        checkCommandFormat(argMultimap);
+        checkCommandFormat(argMultimap, args);
 
         Set<String> newTagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_NEW_TAG));
 
         return new AddTagCommand(newTagList);
     }
 
-    private static void checkCommandFormat(ArgumentMultimap argMultimap) throws ParseException {
+    private static void checkCommandFormat(ArgumentMultimap argMultimap, String args) throws ParseException {
         boolean hasNewTags = !(argMultimap.getAllValues(PREFIX_NEW_TAG).isEmpty());
         boolean hasPreamble = !argMultimap.getPreamble().isEmpty();
 
+        if (args.trim().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_ARGUMENTS_EMPTY,
+                    AddTagCommand.MESSAGE_USAGE));
+        }
+
         if (!hasNewTags) {
-            throw new ParseException(String.format(MESSAGE_NEW_TAG_PREFIX_EMPTY_VALUE,
+            throw new ParseException(String.format(MESSAGE_NEW_TAG_REQUIRED,
                     AddTagCommand.MESSAGE_USAGE));
         }
 

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -9,7 +9,6 @@ public class CliSyntax {
     public static final Prefix PREFIX_NAME = new Prefix("n/");
     public static final Prefix PREFIX_PHONE = new Prefix("p/");
     public static final Prefix PREFIX_EMAIL = new Prefix("e/");
-    public static final Prefix PREFIX_ADDRESS = new Prefix("a/");
     public static final Prefix PREFIX_TAG = new Prefix("t/");
     public static final Prefix PREFIX_NEW_TAG = new Prefix("nt/");
     public static final Prefix PREFIX_POSTAL_CODE = new Prefix("pc/");

--- a/src/main/java/seedu/address/logic/parser/DeleteListingCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteListingCommandParser.java
@@ -1,5 +1,8 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.logic.Messages.MESSAGE_ARGUMENTS_EMPTY;
+import static seedu.address.logic.Messages.MESSAGE_ONE_INDEX_EXPECTED;
+
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.DeleteListingCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -8,6 +11,8 @@ import seedu.address.logic.parser.exceptions.ParseException;
  * Parses input arguments and creates a new {@code DeleteListingCommand} object.
  */
 public class DeleteListingCommandParser implements Parser<DeleteListingCommand> {
+    private static final String WHITESPACE_REGEX = "\\s+";
+    private static final int EXPECTED_PREAMBLE_PARTS = 1;
 
     /**
      * Parses the given {@code String} of arguments in the context of the DeleteListingCommand
@@ -17,8 +22,23 @@ public class DeleteListingCommandParser implements Parser<DeleteListingCommand> 
      * @throws ParseException if the user input does not conform the expected format.
      */
     public DeleteListingCommand parse(String args) throws ParseException {
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args);
+        checkCommandFormat(argMultimap, args);
         Index index = ParserUtil.parseIndex(args);
         return new DeleteListingCommand(index);
+    }
+
+    private static void checkCommandFormat(ArgumentMultimap argMultimap, String args) throws ParseException {
+        String preamble = argMultimap.getPreamble().trim();
+        if (args.trim().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_ARGUMENTS_EMPTY,
+                    DeleteListingCommand.MESSAGE_USAGE));
+        }
+
+        if (preamble.isEmpty() || preamble.split(WHITESPACE_REGEX).length != EXPECTED_PREAMBLE_PARTS) {
+            throw new ParseException(String.format(MESSAGE_ONE_INDEX_EXPECTED,
+                    DeleteListingCommand.MESSAGE_USAGE));
+        }
     }
 
 }

--- a/src/main/java/seedu/address/logic/parser/DeleteListingTagCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteListingTagCommandParser.java
@@ -2,7 +2,7 @@ package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_ARGUMENTS_EMPTY;
 import static seedu.address.logic.Messages.MESSAGE_ONE_INDEX_EXPECTED;
-import static seedu.address.logic.Messages.MESSAGE_PROPERTY_TAG_REQUIRED_FOR_DELETE;
+import static seedu.address.logic.Messages.MESSAGE_LISTING_TAG_REQUIRED_FOR_DELETE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.Set;
@@ -47,7 +47,7 @@ public class DeleteListingTagCommandParser implements Parser<DeleteListingTagCom
         }
 
         if (!hasTags) {
-            throw new ParseException(String.format(MESSAGE_PROPERTY_TAG_REQUIRED_FOR_DELETE,
+            throw new ParseException(String.format(MESSAGE_LISTING_TAG_REQUIRED_FOR_DELETE,
                     DeleteListingTagCommand.MESSAGE_USAGE));
         }
 

--- a/src/main/java/seedu/address/logic/parser/DeleteListingTagCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteListingTagCommandParser.java
@@ -1,8 +1,8 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_ARGUMENTS_EMPTY;
-import static seedu.address.logic.Messages.MESSAGE_ONE_INDEX_EXPECTED;
 import static seedu.address.logic.Messages.MESSAGE_LISTING_TAG_REQUIRED_FOR_DELETE;
+import static seedu.address.logic.Messages.MESSAGE_ONE_INDEX_EXPECTED;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.Set;

--- a/src/main/java/seedu/address/logic/parser/DeletePersonCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeletePersonCommandParser.java
@@ -1,5 +1,8 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.logic.Messages.MESSAGE_ARGUMENTS_EMPTY;
+import static seedu.address.logic.Messages.MESSAGE_ONE_INDEX_EXPECTED;
+
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.DeletePersonCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -8,6 +11,8 @@ import seedu.address.logic.parser.exceptions.ParseException;
  * Parses input arguments and creates a new {@code DeletePersonCommand} object.
  */
 public class DeletePersonCommandParser implements Parser<DeletePersonCommand> {
+    private static final String WHITESPACE_REGEX = "\\s+";
+    private static final int EXPECTED_PREAMBLE_PARTS = 1;
 
     /**
      * Parses the given {@code String} of arguments in the context of the DeletePersonCommand
@@ -17,8 +22,24 @@ public class DeletePersonCommandParser implements Parser<DeletePersonCommand> {
      * @throws ParseException if the user input does not conform the expected format.
      */
     public DeletePersonCommand parse(String args) throws ParseException {
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args);
+        checkCommandFormat(argMultimap, args);
         Index index = ParserUtil.parseIndex(args);
         return new DeletePersonCommand(index);
+    }
+
+    private static void checkCommandFormat(ArgumentMultimap argMultimap, String args) throws ParseException {
+        String preamble = argMultimap.getPreamble().trim();
+
+        if (args.trim().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_ARGUMENTS_EMPTY,
+                    DeletePersonCommand.MESSAGE_USAGE));
+        }
+
+        if (preamble.isEmpty() || preamble.split(WHITESPACE_REGEX).length != EXPECTED_PREAMBLE_PARTS) {
+            throw new ParseException(String.format(MESSAGE_ONE_INDEX_EXPECTED,
+                    DeletePersonCommand.MESSAGE_USAGE));
+        }
     }
 
 }

--- a/src/main/java/seedu/address/logic/parser/DeletePreferenceTagCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeletePreferenceTagCommandParser.java
@@ -2,7 +2,7 @@ package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_ARGUMENTS_EMPTY;
 import static seedu.address.logic.Messages.MESSAGE_EXPECTED_TWO_INDICES;
-import static seedu.address.logic.Messages.MESSAGE_PROPERTY_TAG_REQUIRED_FOR_DELETE;
+import static seedu.address.logic.Messages.MESSAGE_LISTING_TAG_REQUIRED_FOR_DELETE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.List;
@@ -54,7 +54,7 @@ public class DeletePreferenceTagCommandParser implements Parser<DeletePreference
         }
 
         if (!hasTags) {
-            throw new ParseException(String.format(MESSAGE_PROPERTY_TAG_REQUIRED_FOR_DELETE,
+            throw new ParseException(String.format(MESSAGE_LISTING_TAG_REQUIRED_FOR_DELETE,
                     DeletePreferenceTagCommand.MESSAGE_USAGE));
         }
 

--- a/src/main/java/seedu/address/logic/parser/DeleteTagCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteTagCommandParser.java
@@ -1,11 +1,13 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.logic.Messages.MESSAGE_ARGUMENTS_EMPTY;
 import static seedu.address.logic.Messages.MESSAGE_DELETE_TAG_PREAMBLE_FOUND;
 import static seedu.address.logic.Messages.MESSAGE_TAG_REQUIRED_FOR_DELETE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.Set;
 
+import seedu.address.logic.commands.DeletePreferenceTagCommand;
 import seedu.address.logic.commands.DeleteTagCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
@@ -24,15 +26,20 @@ public class DeleteTagCommandParser implements Parser<DeleteTagCommand> {
     public DeleteTagCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_TAG);
         argMultimap.verifyNoDuplicateTagValues(DeleteTagCommand.MESSAGE_USAGE);
-        checkCommandFormat(argMultimap);
+        checkCommandFormat(argMultimap, args);
 
         Set<String> deleteTagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
 
         return new DeleteTagCommand(deleteTagList);
     }
 
-    private static void checkCommandFormat(ArgumentMultimap argMultimap) throws ParseException {
+    private static void checkCommandFormat(ArgumentMultimap argMultimap, String args) throws ParseException {
         boolean hasTags = !(argMultimap.getAllValues(PREFIX_TAG).isEmpty());
+
+        if (args.trim().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_ARGUMENTS_EMPTY,
+                    DeleteTagCommand.MESSAGE_USAGE));
+        }
 
         if (!hasTags) {
             throw new ParseException(String.format(MESSAGE_TAG_REQUIRED_FOR_DELETE,

--- a/src/main/java/seedu/address/logic/parser/DeleteTagCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteTagCommandParser.java
@@ -7,7 +7,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.Set;
 
-import seedu.address.logic.commands.DeletePreferenceTagCommand;
 import seedu.address.logic.commands.DeleteTagCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 

--- a/src/main/java/seedu/address/logic/parser/EditPersonCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditPersonCommandParser.java
@@ -32,14 +32,9 @@ public class EditPersonCommandParser implements Parser<EditPersonCommand> {
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL);
 
-        Index index;
-
         checkCommandFormat(argMultimap, args);
-
-        index = ParserUtil.parseIndex(argMultimap.getPreamble());
-
+        Index index = ParserUtil.parseIndex(argMultimap.getPreamble());
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL);
-
         EditPersonDescriptor editPersonDescriptor = new EditPersonDescriptor();
 
         if (argMultimap.getValue(PREFIX_NAME).isPresent()) {

--- a/src/main/java/seedu/address/logic/parser/MarkAvailableCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/MarkAvailableCommandParser.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_ARGUMENTS_EMPTY;
+import static seedu.address.logic.Messages.MESSAGE_ONE_INDEX_EXPECTED;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.MarkAvailableCommand;
@@ -10,6 +11,8 @@ import seedu.address.logic.parser.exceptions.ParseException;
  * Parses input arguments and creates a new {@code MarkAvailableCommand} object.
  */
 public class MarkAvailableCommandParser implements Parser<MarkAvailableCommand> {
+    private static final String WHITESPACE_REGEX = "\\s+";
+    private static final int EXPECTED_PREAMBLE_PARTS = 1;
     /**
      * Parses the given {@code String} of arguments in the context of the MarkAvailableCommand
      * and returns a MarkAvailableCommand object for execution.
@@ -18,14 +21,21 @@ public class MarkAvailableCommandParser implements Parser<MarkAvailableCommand> 
      * @throws ParseException if the user input does not conform the expected format.
      */
     public MarkAvailableCommand parse(String args) throws ParseException {
-        checkCommandFormat(args);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args);
+        checkCommandFormat(argMultimap, args);
         Index index = ParserUtil.parseIndex(args);
         return new MarkAvailableCommand(index);
     }
 
-    private static void checkCommandFormat(String args) throws ParseException {
+    private static void checkCommandFormat(ArgumentMultimap argMultimap, String args) throws ParseException {
+        String preamble = argMultimap.getPreamble().trim();
         if (args.trim().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_ARGUMENTS_EMPTY,
+                    MarkAvailableCommand.MESSAGE_USAGE));
+        }
+
+        if (preamble.isEmpty() || preamble.split(WHITESPACE_REGEX).length != EXPECTED_PREAMBLE_PARTS) {
+            throw new ParseException(String.format(MESSAGE_ONE_INDEX_EXPECTED,
                     MarkAvailableCommand.MESSAGE_USAGE));
         }
     }

--- a/src/main/java/seedu/address/logic/parser/MarkUnavailableCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/MarkUnavailableCommandParser.java
@@ -2,6 +2,7 @@ package seedu.address.logic.parser;
 
 
 import static seedu.address.logic.Messages.MESSAGE_ARGUMENTS_EMPTY;
+import static seedu.address.logic.Messages.MESSAGE_ONE_INDEX_EXPECTED;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.MarkUnavailableCommand;
@@ -11,6 +12,8 @@ import seedu.address.logic.parser.exceptions.ParseException;
  * Parses input arguments and creates a new {@code MarkUnavailableCommand} object.
  */
 public class MarkUnavailableCommandParser implements Parser<MarkUnavailableCommand> {
+    private static final String WHITESPACE_REGEX = "\\s+";
+    private static final int EXPECTED_PREAMBLE_PARTS = 1;
 
     /**
      * Parses the given {@code String} of arguments in the context of the MarkUnavailableCommand
@@ -20,14 +23,21 @@ public class MarkUnavailableCommandParser implements Parser<MarkUnavailableComma
      * @throws ParseException if the user input does not conform the expected format.
      */
     public MarkUnavailableCommand parse(String args) throws ParseException {
-        checkCommandFormat(args);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args);
+        checkCommandFormat(argMultimap, args);
         Index index = ParserUtil.parseIndex(args);
         return new MarkUnavailableCommand(index);
     }
 
-    private static void checkCommandFormat(String args) throws ParseException {
+    private static void checkCommandFormat(ArgumentMultimap argMultimap, String args) throws ParseException {
+        String preamble = argMultimap.getPreamble().trim();
         if (args.trim().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_ARGUMENTS_EMPTY,
+                    MarkUnavailableCommand.MESSAGE_USAGE));
+        }
+
+        if (preamble.isEmpty() || preamble.split(WHITESPACE_REGEX).length != EXPECTED_PREAMBLE_PARTS) {
+            throw new ParseException(String.format(MESSAGE_ONE_INDEX_EXPECTED,
                     MarkUnavailableCommand.MESSAGE_USAGE));
         }
     }

--- a/src/main/java/seedu/address/logic/parser/MatchListingCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/MatchListingCommandParser.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_ARGUMENTS_EMPTY;
+import static seedu.address.logic.Messages.MESSAGE_ONE_INDEX_EXPECTED;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.MatchListingCommand;
@@ -10,7 +11,8 @@ import seedu.address.logic.parser.exceptions.ParseException;
  * Parses input arguments and creates a new {@code MatchListingCommand} object.
  */
 public class MatchListingCommandParser implements Parser<MatchListingCommand> {
-
+    private static final String WHITESPACE_REGEX = "\\s+";
+    private static final int EXPECTED_PREAMBLE_PARTS = 1;
     /**
      * Parses the given {@code String} of arguments in the context of the MatchListingCommand
      * and returns a MatchListingCommand object for execution.
@@ -19,14 +21,21 @@ public class MatchListingCommandParser implements Parser<MatchListingCommand> {
      * @throws ParseException if the user input does not conform the expected format.
      */
     public MatchListingCommand parse(String args) throws ParseException {
-        checkCommandFormat(args);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args);
+        checkCommandFormat(argMultimap, args);
         Index index = ParserUtil.parseIndex(args);
         return new MatchListingCommand(index);
     }
 
-    private static void checkCommandFormat(String args) throws ParseException {
+    private static void checkCommandFormat(ArgumentMultimap argMultimap, String args) throws ParseException {
+        String preamble = argMultimap.getPreamble().trim();
         if (args.trim().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_ARGUMENTS_EMPTY,
+                    MatchListingCommand.MESSAGE_USAGE));
+        }
+
+        if (preamble.isEmpty() || preamble.split(WHITESPACE_REGEX).length != EXPECTED_PREAMBLE_PARTS) {
+            throw new ParseException(String.format(MESSAGE_ONE_INDEX_EXPECTED,
                     MatchListingCommand.MESSAGE_USAGE));
         }
     }

--- a/src/main/java/seedu/address/logic/parser/SearchListingByTagCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SearchListingByTagCommandParser.java
@@ -13,7 +13,6 @@ import seedu.address.logic.parser.exceptions.ParseException;
  * Parses input arguments and creates a new {@code SearchListingByTagCommand} object.
  */
 public class SearchListingByTagCommandParser implements Parser<SearchListingByTagCommand> {
-
     /**
      * Parses the given {@code String} of arguments in the context of the SearchListingByTagCommand
      * and returns a SearchListingByTagCommand object for execution.
@@ -46,7 +45,7 @@ public class SearchListingByTagCommandParser implements Parser<SearchListingByTa
         }
 
         if (!argMultimap.getPreamble().isEmpty()) {
-            throw new ParseException(String.format(Messages.MESSAGE_SEARCH_PROPERTY_TAG_PREAMBLE_FOUND,
+            throw new ParseException(String.format(Messages.MESSAGE_SEARCH_LISTING_TAG_PREAMBLE_FOUND,
                     SearchListingByTagCommand.MESSAGE_USAGE));
         }
     }

--- a/src/main/java/seedu/address/logic/parser/SearchOwnerListingCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SearchOwnerListingCommandParser.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_ARGUMENTS_EMPTY;
+import static seedu.address.logic.Messages.MESSAGE_ONE_INDEX_EXPECTED;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.SearchOwnerListingCommand;
@@ -10,7 +11,8 @@ import seedu.address.logic.parser.exceptions.ParseException;
  * Parses input arguments and creates a new {@code SearchOwnerListingCommand} object.
  */
 public class SearchOwnerListingCommandParser implements Parser<SearchOwnerListingCommand> {
-
+    private static final String WHITESPACE_REGEX = "\\s+";
+    private static final int EXPECTED_PREAMBLE_PARTS = 1;
     /**
      * Parses the given {@code String} of arguments in the context of the SearchOwnerListingCommand
      * and returns a SearchOwnerListingCommand object for execution.
@@ -19,14 +21,21 @@ public class SearchOwnerListingCommandParser implements Parser<SearchOwnerListin
      * @throws ParseException if the user input does not conform the expected format.
      */
     public SearchOwnerListingCommand parse(String args) throws ParseException {
-        checkCommandFormat(args);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args);
+        checkCommandFormat(argMultimap, args);
         Index index = ParserUtil.parseIndex(args);
         return new SearchOwnerListingCommand(index);
     }
 
-    private static void checkCommandFormat(String args) throws ParseException {
+    private static void checkCommandFormat(ArgumentMultimap argMultimap, String args) throws ParseException {
+        String preamble = argMultimap.getPreamble().trim();
         if (args.trim().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_ARGUMENTS_EMPTY,
+                    SearchOwnerListingCommand.MESSAGE_USAGE));
+        }
+
+        if (preamble.isEmpty() || preamble.split(WHITESPACE_REGEX).length != EXPECTED_PREAMBLE_PARTS) {
+            throw new ParseException(String.format(MESSAGE_ONE_INDEX_EXPECTED,
                     SearchOwnerListingCommand.MESSAGE_USAGE));
         }
     }

--- a/src/test/java/seedu/address/logic/commands/DeleteListingTagCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteListingTagCommandTest.java
@@ -94,12 +94,12 @@ public class DeleteListingTagCommandTest {
 
         // Sort tags to make output deterministic
         List<String> sortedTags = tagsToRemove.stream().sorted().collect(Collectors.toList());
-        String expectedMessage = String.format(Messages.MESSAGE_DELETE_PROPERTY_TAG_SUCCESS,
+        String expectedMessage = String.format(Messages.MESSAGE_DELETE_LISTING_TAG_SUCCESS,
                 sampleListing.getPostalCode(), sortedTags);
         assertTrue(result.getFeedbackToUser().contains(sampleListing.getPostalCode().toString()));
         assertEquals(
                 expectedMessage,
-                String.format(Messages.MESSAGE_DELETE_PROPERTY_TAG_SUCCESS,
+                String.format(Messages.MESSAGE_DELETE_LISTING_TAG_SUCCESS,
                         sampleListing.getPostalCode(), tagsToRemove)
         );
     }

--- a/src/test/java/seedu/address/logic/commands/SearchListingByTagCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SearchListingByTagCommandTest.java
@@ -99,7 +99,7 @@ public class SearchListingByTagCommandTest {
         SearchListingByTagCommand command = new SearchListingByTagCommand(tagsToSearch);
 
         CommandResult result = command.execute(model);
-        assertEquals(Messages.MESSAGE_SEARCH_PROPERTY_TAGS_NO_MATCH, result.getFeedbackToUser());
+        assertEquals(Messages.MESSAGE_SEARCH_LISTING_TAGS_NO_MATCH, result.getFeedbackToUser());
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/SearchListingByTagCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SearchListingByTagCommandTest.java
@@ -78,7 +78,7 @@ public class SearchListingByTagCommandTest {
         SearchListingByTagCommand command = new SearchListingByTagCommand(tagsToSearch);
 
         CommandResult result = command.execute(model);
-        assertEquals("1 properties matching the tags!", result.getFeedbackToUser());
+        assertEquals("1 listings matching the tags!", result.getFeedbackToUser());
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/DeleteListingTagCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteListingTagCommandParserTest.java
@@ -1,7 +1,7 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.Messages.MESSAGE_PROPERTY_TAG_REQUIRED_FOR_DELETE;
+import static seedu.address.logic.Messages.MESSAGE_LISTING_TAG_REQUIRED_FOR_DELETE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
@@ -35,7 +35,7 @@ public class DeleteListingTagCommandParserTest {
     @Test
     public void parse_missingIndex_failure() {
         String userInput = PREFIX_TAG + "pet-friendly";
-        String expectedMessage = String.format(MESSAGE_PROPERTY_TAG_REQUIRED_FOR_DELETE,
+        String expectedMessage = String.format(MESSAGE_LISTING_TAG_REQUIRED_FOR_DELETE,
                 DeleteListingTagCommand.MESSAGE_USAGE);
 
         assertParseFailure(parser, userInput, expectedMessage);
@@ -44,7 +44,7 @@ public class DeleteListingTagCommandParserTest {
     @Test
     public void parse_missingTags_failure() {
         String userInput = "3"; // No tags provided
-        String expectedMessage = String.format(MESSAGE_PROPERTY_TAG_REQUIRED_FOR_DELETE,
+        String expectedMessage = String.format(MESSAGE_LISTING_TAG_REQUIRED_FOR_DELETE,
                 DeleteListingTagCommand.MESSAGE_USAGE);
 
         assertParseFailure(parser, userInput, expectedMessage);


### PR DESCRIPTION
Fixes #388 

Note for XY:
The following success response messages has been changed because they still used "property" instead of "listing". These include:
SearchListingTags and DeleteListingTag